### PR TITLE
Potential fix for code scanning alert no. 198: Type confusion through parameter tampering

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -19,6 +19,9 @@ class ErrorWithParent extends Error {
 export function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
     let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    if (typeof criteria !== 'string') {
+      criteria = ''
+    }
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
Potential fix for [https://github.com/M365x81870695/juice-shop/security/code-scanning/198](https://github.com/M365x81870695/juice-shop/security/code-scanning/198)

To fix the problem, we need to ensure that the `criteria` variable is always a string before performing string operations on it. The best way to do this is to check the type of `req.query.q` (or `criteria`) and only proceed if it is a string. If it is not a string (e.g., it is an array or any other type), we should default to an empty string or handle it as an invalid input. This change should be made in the region where `criteria` is assigned and sanitized, specifically lines 21-22 in `routes/search.ts`. No new methods or complex logic are needed; a simple type check using `typeof` will suffice.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
